### PR TITLE
Possible fix for EnumMacros.materializeEnumImpl (#2)

### DIFF
--- a/src/main/scala/EnumMacros.scala
+++ b/src/main/scala/EnumMacros.scala
@@ -53,8 +53,8 @@ object EnumMacros {
     import q.reflect._
     val tType = TypeRepr.of[T]
     tType match {
-      case andType: AndOrType => {
-        andType.right match {
+      // case andType: AndOrType => {
+      //   andType.right match {
           case apType: AppliedType => {
             val lastTypeRef     = apType.args.last
             val companionSymbol = lastTypeRef.typeSymbol.companionModule
@@ -99,11 +99,11 @@ object EnumMacros {
           case _ =>
             report.throwError("unexpected")
         }
-      }
-      case _ => {
-        report.throwError("meh")
-      }
-    }
+    //   }
+    //   case _ => {
+    //     report.throwError("meh")
+    //   }
+    // }
 
   }
 }

--- a/src/test/scala/Test1.scala
+++ b/src/test/scala/Test1.scala
@@ -24,11 +24,7 @@ trait TestEnum[T <: TestEnumEntry] {
 
 }
 
-object TestEnum {
-  implicit inline def materializeEnum[A <: TestEnumEntry]: A = EnumMacros.materializeEnumImpl[A]
-}
-
-def getEnumForEntry[A <: TestEnumEntry: TestEnum](a: A): TestEnum[A] = implicitly[TestEnum[A]]
+inline def getEnumForEntry[A <: TestEnumEntry](a: A): TestEnum[A] = EnumMacros.materializeEnumImpl[TestEnum[A]]
 
 sealed trait SomeEnum extends TestEnumEntry
 


### PR DESCRIPTION
The tests pass with these changes. Does that help?

 - The match in `EnumMacros._materializeEnumImpl` seemed to have an extra level of nested that wasn't needed

 - The materializeEnum method seemed redundant so I removed it from the PR but it also works with if you modify the return type to be a `TestEnum[A]`:

```scala
object TestEnum {
  implicit inline def materializeEnum[A <: TestEnumEntry]: TestEnum[A] = EnumMacros.materializeEnumImpl[A]
}

def getEnumForEntry[A <: TestEnumEntry: TestEnum](a: A): TestEnum[A] = implicitly[TestEnum[A]]
```